### PR TITLE
Support React

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,23 @@ $ yarn add -D @netsells/storybook-mockdate
 
 Provide the decorator in your storybook decorators config:
 
+#### Vue
+
 ```js
 import withMockdate from '@netsells/storybook-mockdate';
 
 export default [
     withMockdate,
+];
+```
+
+#### React
+
+```js
+import { withMockdateReact } from '@netsells/storybook-mockdate';
+
+export default [
+    withMockdateReact,
 ];
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,3 +31,38 @@ export default (story, { parameters }) => {
 
     return story();
 };
+
+function withMockdateReact(story, { parameters }) {
+    mockdate.reset();
+
+    // Allows us to "time travel" to ensure our stories don't change over time
+    if (parameters.mockdate) {
+        mockdate.set(parameters.mockdate)
+
+        const mockedDate = dayjs(parameters.mockdate).format('DD-MM-YYYY HH:mma');
+
+        return (
+            <div>
+                <story />
+                <div
+                    style={{
+                        position: 'fixed',
+                        bottom: 0,
+                        right: 0,
+                        background: 'rgba(0, 0, 0, 0.15)',
+                        padding: '5px',
+                        lineHeight: 1,
+                    }}
+                >
+                    Mocking date: { mockedDate }
+                </div>
+            </div>
+        );
+    }
+
+    return story();
+}
+
+export {
+    withMockdateReact,
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@netsells/storybook-mockdate",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "main": "./dist/index.js",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging
<!-- Remove the below if this project doesn't have tests (maybe it should?) -->
- [ ] New and existing tests pass locally with my changes
- [ ] The code modified as part of this PR has been covered with tests

### Problem statement
The current default export only support Vue implementation. This adds support for React as requested in #1.

### Solution
Add a separate named export for React decorator.

