### PR TITLE
Fix bug which stops plugin from working in storybook 8

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,15 +16,20 @@ export default ((story, {
     mockdate.set(parameters.mockdate);
 
     const mockedDate = dayjs(parameters.mockdate).format('DD-MM-YYYY HH:mma');
+    const framework = parameters.framework || parameters.renderer;
 
-    switch (parameters.framework) {
+    switch (framework) {
+        // The docs aren't clear as to whether parameters.renderer returns "@storybook/react" or "react"
+        case '@storybook/react':
         case 'react':
             return reactOverlay(story, mockedDate);
 
+        case '@storybook/vue':
+        case '@storybook/vue3':
         case 'vue':
         case 'vue3':
             return vueOverlay(mockedDate);
     }
 
-    throw new Error(`Framework [${ parameters.framework }] not supported.`);
+    throw new Error(`Framework [${ framework }] not supported.`);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@netsells/storybook-mockdate",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "main": "./dist/index.js",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient logging
<!-- Remove the below if this project doesn't have tests (maybe it should?) -->
- [x] New and existing tests pass locally with my changes
- [x] The code modified as part of this PR has been covered with tests
<!-- Remove the below if this project doesn't include an API -->
- [x] The API spec has been modified inline with the changes in this PR

### Problem statement
This plugin doesn't work with my Storybook 8 steup. When I did some debugging it was because `parameters.framework` is undefined. I noticed that `parameters.renderer` value was `react`. I looked into the documentation and I couldn't really find anything about this value. I looked into `@storybook/react` and saw they set the renderer as `@storybook/react` at times, however even though I'm using `@storybook/react` I get `renderer: 'react'`.

### Solution
If `parameters.framework` is empty, use `parameters.renderer` and check for both `react|vue|vue3` and `@storybook/react | @storybook/vue | @storybook/vue3`.

This change fixes my issue with `@storybook/react` and storybook 8.

## Deployment

### Migrations
No